### PR TITLE
Order Test Local Methods By MetadataToken

### DIFF
--- a/src/LoFuUnit/LoFuTest.cs
+++ b/src/LoFuUnit/LoFuTest.cs
@@ -46,6 +46,7 @@ namespace LoFuUnit
                                     .Where(x => x.ReturnType == typeof(void))
                                     .Where(x => x.GetParameters().Length == 0)
                                     .Where(x => x.Name.StartsWith(testMethod.WrappedName()))
+                                    .OrderBy(x => x.MetadataToken)
                                     .ToList() ?? Enumerable.Empty<MethodInfo>().ToList();
 
             Log(testMethod.GetFormattedName());
@@ -68,6 +69,7 @@ namespace LoFuUnit
                                     .Where(x => x.ReturnType == typeof(void) || x.ReturnType == typeof(Task))
                                     .Where(x => x.GetParameters().Length == 0)
                                     .Where(x => x.Name.StartsWith(testMethod.WrappedName()))
+                                    .OrderBy(x => x.MetadataToken)
                                     .ToList() ?? Enumerable.Empty<MethodInfo>().ToList();
 
             Log(testMethod.GetFormattedName());


### PR DESCRIPTION
fix for the bug here:
https://github.com/hlaueriksson/LoFuUnit/issues/5
MetadataToken does not necessarily order all objects lexically, however I believe it does when only considering methods (see https://github.com/dotnet/roslyn/issues/16733).