### PR TITLE
Fix: Lambda expression

### DIFF
--- a/src/LoFuUnit/InternalNamingExtensions.cs
+++ b/src/LoFuUnit/InternalNamingExtensions.cs
@@ -15,7 +15,7 @@ namespace LoFuUnit
 
         internal static string WrappedName(this MethodBase testMethod)
         {
-            return Gt + testMethod.Name + Lt;
+            return Gt + testMethod.Name + Lt + Prefix;
         }
 
         internal static string GetFormattedName(this MethodBase testMethod)

--- a/tests/LoFuUnit.Tests/Integration/FailSubject.cs
+++ b/tests/LoFuUnit.Tests/Integration/FailSubject.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace LoFuUnit.Tests.Integration
+{
+    public class FailSubject
+    {
+        public void Fail()
+        {
+            throw new Exception("Fail");
+        }
+
+        public async Task FailAsync()
+        {
+            await Task.Delay(1);
+
+            throw new Exception("Fail");
+        }
+    }
+}

--- a/tests/LoFuUnit.Tests/Integration/LoFuTestRegressionTests.cs
+++ b/tests/LoFuUnit.Tests/Integration/LoFuTestRegressionTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace LoFuUnit.Tests.Integration
+{
+    public class LoFuTestRegressionTests : LoFuTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            Subject = new FailSubject();
+        }
+
+        // Message:
+        //  System.ArgumentOutOfRangeException : StartIndex cannot be less than zero. (Parameter 'startIndex')
+        // Stack Trace:
+        //  String.Remove(Int32 startIndex)
+        //  InternalNamingExtensions.GetFunctionName(MethodInfo testFunction, MethodBase testMethod)
+        //  LoFuTest.AssertAsync(Object testFixture, MethodBase testMethod)
+        //  InternalLoFuTestExtensions.AssertAsync(Object fixture, MethodBase method)
+        //  <.ctor>b__0_0(TestExecutionContext context)
+        //  AfterTestCommand.Execute(TestExecutionContext context)
+        //  SimpleWorkItem.PerformWork()
+        [Test]
+        public async Task when_invoking_test_fixture_member_with_lambda_expression()
+        {
+            await AssertAsync();
+
+            async Task should_not_crash()
+            {
+                Func<Task> act = () => Subject.FailAsync();
+                await act.Should().ThrowAsync<Exception>();
+            }
+        }
+
+        FailSubject Subject;
+    }
+}

--- a/tests/LoFuUnit.Tests/Integration/LoFuTestTests.cs
+++ b/tests/LoFuUnit.Tests/Integration/LoFuTestTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NUnit.Framework;
@@ -165,20 +165,5 @@ namespace LoFuUnit.Tests.Integration
         }
 
         int Subject;
-    }
-
-    public class FailSubject
-    {
-        public void Fail()
-        {
-            throw new Exception("Fail");
-        }
-
-        public async Task FailAsync()
-        {
-            await Task.Delay(1);
-
-            throw new Exception("Fail");
-        }
     }
 }

--- a/tests/LoFuUnit.Tests/Integration/LoFuTestTests.cs
+++ b/tests/LoFuUnit.Tests/Integration/LoFuTestTests.cs
@@ -37,16 +37,16 @@ namespace LoFuUnit.Tests.Integration
         }
 
         [Test]
-        public void when_Assert_with_Func_Task()
+        public void when_Assert_with_Action()
         {
             Assert();
 
-            void should_invoke_local_function_with_Func_Task_expression()
+            void should_invoke_local_function_with_Action_expression()
             {
-                var subject = new FakeAsyncSubject();
+                var subject = new FailSubject();
 
-                Func<Task> act = async () => { await subject.Fail(); };
-                act.Should().ThrowAsync<Exception>();
+                Action act = subject.Fail;
+                act.Should().Throw<Exception>();
             }
         }
 
@@ -100,12 +100,12 @@ namespace LoFuUnit.Tests.Integration
         {
             await AssertAsync();
 
-            void should_invoke_local_function_with_Func_Task_expression()
+            async Task should_invoke_local_function_with_Func_Task_expression()
             {
-                var subject = new FakeAsyncSubject();
+                var subject = new FailSubject();
 
-                Func<Task> act = async () => { await subject.Fail(); };
-                act.Should().ThrowAsync<Exception>();
+                Func<Task> act = subject.FailAsync;
+                await act.Should().ThrowAsync<Exception>();
             }
         }
 
@@ -167,9 +167,14 @@ namespace LoFuUnit.Tests.Integration
         int Subject;
     }
 
-    public class FakeAsyncSubject
+    public class FailSubject
     {
-        public async Task Fail()
+        public void Fail()
+        {
+            throw new Exception("Fail");
+        }
+
+        public async Task FailAsync()
         {
             await Task.Delay(1);
 

--- a/tests/LoFuUnit.Tests/LoFuUnit/InternalNamingExtensionsTests.cs
+++ b/tests/LoFuUnit.Tests/LoFuUnit/InternalNamingExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NUnit.Framework;
@@ -10,7 +10,7 @@ namespace LoFuUnit.Tests.LoFuUnit
         [Test]
         public void WrappedName()
         {
-            typeof(FakeTestFixture).GetMethod(nameof(FakeTestFixture.A_b_c)).WrappedName().Should().Be("<A_b_c>");
+            typeof(FakeTestFixture).GetMethod(nameof(FakeTestFixture.A_b_c)).WrappedName().Should().Be("<A_b_c>g__");
         }
 
         [Test]


### PR DESCRIPTION
Invoking a test fixture member with a lambda expression resulted in a crash:

```
Message:
  System.ArgumentOutOfRangeException : StartIndex cannot be less than zero. (Parameter 'startIndex')
Stack Trace:
  String.Remove(Int32 startIndex)
  InternalNamingExtensions.GetFunctionName(MethodInfo testFunction, MethodBase testMethod)
  LoFuTest.AssertAsync(Object testFixture, MethodBase testMethod)
  InternalLoFuTestExtensions.AssertAsync(Object fixture, MethodBase method)
  <.ctor>b__0_0(TestExecutionContext context)
  AfterTestCommand.Execute(TestExecutionContext context)
  SimpleWorkItem.PerformWork()
```

This would for example happen when using `FluentAssertions` and testing exceptions:

```cs
Func<Task> act = () => asyncObject.ThrowAsync<ArgumentException>();
await act.Should().ThrowAsync<InvalidOperationException>();
```

See https://fluentassertions.com/exceptions/